### PR TITLE
tagging for the private link service endpoint resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,8 @@ resource "aws_vpc_endpoint_service" "service_provider" {
   network_load_balancer_arns = ["${var.nlb_arns}"]
 
   tags = {
-    Name             = "${var.service_name}"
+    Name             = "${var.service_name}-vpce"
+    Service          = "${var.service_name}"
     Description      = "${var.description}"
     Environment      = "${var.environment}"
     ProductDomain    = "${var.product_domain}"

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,19 @@
 resource "aws_vpc_endpoint_service" "service_provider" {
   acceptance_required        = "${var.acceptance_required}"
   network_load_balancer_arns = ["${var.nlb_arns}"]
+
+  tags = {
+    Name             = "${var.service_name}"
+    Description      = "${var.description}"
+    Environment      = "${var.environment}"
+    ProductDomain    = "${var.product_domain}"
+    ManagedBy        = "terraform"
+  }
 }
 
 resource "aws_vpc_endpoint_service_allowed_principal" "service_provider" {
   vpc_endpoint_service_id = "${aws_vpc_endpoint_service.service_provider.id}"
   count                   = "${length(var.allowed_principals)}"
   principal_arn           = "${element(var.allowed_principals, count.index)}"
+
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,24 @@ variable "acceptance_required" {
   default     = false
   description = "Whether or not VPC endpoint connection requests to the service must be accepted by the service owner"
 }
+
+variable "service_name" {
+  type        = "string"
+  description = "Stack name of the Service Endpoint"
+}
+
+variable "description" {
+  type        = "string"
+  default     = ""
+  description = "Description of the Service Endpoint"
+}
+
+variable "environment" {
+  type        = "string"
+  description = "Will be used in resources' Environment tag"
+}
+
+variable "product_domain" {
+  type        = "string"
+  description = "Abbreviation of the product domain the created resources belong to"
+}


### PR DESCRIPTION
## Summary
Resolves #5 

There is no tagging for the created service endpoint because of that very hard to differentiate. 

## Subscribe
- @febryantonius 
- @nuradhi 
- @rafikurnia 