### PR TITLE
Update Name tagging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "aws_vpc_endpoint_service" "service_provider" {
   network_load_balancer_arns = ["${var.nlb_arns}"]
 
   tags = {
-    Name             = "${var.service_name}-vpce"
+    Name             = "${var.service_name}-vpces"
     Service          = "${var.service_name}"
     Description      = "${var.description}"
     Environment      = "${var.environment}"


### PR DESCRIPTION
I have discussion with Febri that for consumer `Name` tag will using suffix `-vpce` and for provider `Name` tag will using suffix `-vpces`.
`vpce` means VPC endpoint.
`vpces` means VPC endpoint service.